### PR TITLE
fix: make number of TelephonyParty optional as it is not always present

### DIFF
--- a/wxc_sdk/telephony/calls.py
+++ b/wxc_sdk/telephony/calls.py
@@ -90,7 +90,7 @@ class TelephonyParty(ApiModel):
     name: Optional[str] = None
     #: The party's number. Only present when the number is available and privacy is not enabled. The number can be
     #: digits or a URI. Some examples for number include: 1234, 2223334444, +12223334444, \*73, user@company.domain
-    number: str
+    number: Optional[str] = None
     #: The party's person ID. Only present when the person ID is available and privacy is not enabled.
     person_id: Optional[str] = None
     #: The party's place ID. Only present when the place ID is available and privacy is not enabled.


### PR DESCRIPTION
When I'm trying to get active calls (telephony.calls.list_calls()) the number of the TelephonyParty is not present when the caller is anonymous, which causes a Pydantic ValidationError:

> 1 validation error for list[TelephonyCall]
> 0.remoteParty.number
>   Field required [type=missing, input_value={'privacyEnabled': True, 'callType': 'external'}, input_type=dict]

Therefore I suggest the number property to be optional as the rest of the TelephonyParty properties.